### PR TITLE
Update pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,12 @@ repos:
     hooks:
     -   id: flake8
         args: ['src']
+-   repo: https://github.com/Yelp/detect-secrets
+    rev: v0.13.1
+    hooks:
+    -   id: detect-secrets
+        args: ['--baseline', '.secrets.baseline']
+        exclude: .*/tests/.*
 -   repo: https://github.com/aflc/pre-commit-jupyter
     rev: v1.1.0
     hooks:
@@ -19,7 +25,5 @@ repos:
     hooks:
     -   id: check-added-large-files
         args: ['--maxkb=5120']
-    -   id: detect-aws-credentials
-    -   id: detect-private-key
     -   id: end-of-file-fixer
     -   id: trailing-whitespace

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,594 @@
+{
+  "exclude": {
+    "files": null,
+    "lines": null
+  },
+  "generated_at": "2020-04-02T16:23:12Z",
+  "plugins_used": [
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "base64_limit": 4.5,
+      "name": "Base64HighEntropyString"
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "hex_limit": 3,
+      "name": "HexHighEntropyString"
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "keyword_exclude": null,
+      "name": "KeywordDetector"
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "results": {
+    "renv.lock": [
+      {
+        "hashed_secret": "aec46170e092bef4396836ac09dc0ccae055b27b",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 17,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "d00a0fe689bdce88d55712ff9cb8e83c58d2b5e4",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 24,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "4771f9b5c581b5d74c6539f48bde0c127cfff44a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 31,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "8bc5670ef4c67da42f22a13b9270b2b11e9d30d7",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 38,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "a6e9f44ffb1407abf5761750b0fd38d39d2fe9bc",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 45,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "9d418978ca44a5d2888b08a47c58042b76bca2aa",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 52,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "19c6b26bb98dcfa8794dc62dbc4bbdd0939c354e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 59,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "593a57c881de09bc668190d3dfebdfa775a50a48",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 66,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "e530f50339e95418a8ad90ca457da5f05185c0e9",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 73,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "ca321d646b2bc77f2ef7931d23dfd26c8ee10c60",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 80,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "a649143ffb866fffbaea15fa1a927cbde6278b1d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 87,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "269b91554525afbd6bd12a8dd4095ef24598ff35",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 94,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "181c34f65733632ee0d3b4b37a8a26c43c8fb945",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 101,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "b18f18f5d1be8d7d15de506fbbff9fc1338c1c36",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 108,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "24f5550a7b0805fc16730a4f733a028bd2dbc374",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 115,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "c1f608f29d6e1195d9cd81a9168f56d94190dfae",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 122,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "82bba3613668a62af5f460de804cf70d84f7c8dc",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 129,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "0bbecee745055890114eb4147c4a550ea236264d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 136,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "f46d18a231276b3e6d419c530e333b57bce3f7d7",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 143,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "0d38a68dc582bcf40b1bdffb151bf0e7165b9fff",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 150,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "4c8b0da932170447804b6d6093f0b97079c39757",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 157,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "5c95427f585a3f86c72bf62df6ec50ffe2a5162d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 164,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "3bbb8ae70a364c565bbd60a8c2e0d652f3334237",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 171,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "854502541c7a8e3088bf3eadcdf2a9f8742ff976",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 178,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "bbe625a4c4955fdfad59469f04a1ae074fdb0fca",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 185,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "0ec30a43b2802e183776f57a0b80a0a8913db1b5",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 192,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "36393a9c76f63dc1078e2c57070d8a4d0db5f2dd",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 199,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "25eaff7297bb55f1b6d7d8e9d59070d4bf8eb073",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 206,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "173ed90c655b24a70c5659eecc2cb3eee0829f07",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 213,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "3b6784b8e6aec7957bebe40bc0094182caa69934",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 220,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "42eba06690eb2d1ce3484031982a47f1d3ffd0ad",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 227,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "6cd6e785d88352dfeb12f324b52ab89c8e992fca",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 234,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "bde444c84c2ba48471984c1b887af79049ac3b5d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 241,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "cd97dce3d10beb7e39e21430d8112362d619fc5c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 248,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "2293dcf141bba90c50868ead03efdad89584e14e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 255,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "4b828ec574989ca709507188a508b3a286aa10ec",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 262,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "ae64637b941d3f8dec41e25dfaa7232ccd97663f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 269,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "41cefad6e550d208ee83519158991db627d3f2ba",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 276,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "67f9f75582deec38002ca162a5518c1124936f1b",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 283,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "a3fcf41e52aabe7c336e9cc408061b07248c96b9",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 290,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "1392e4fd3f9c7322f4a5703a1512711b125d2a66",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 297,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "f939f2ba5bb1fb3232e4b05d825ad962a9651932",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 304,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "37d83c8c0bdff283805c5ee63a715e1cb8121ef1",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 311,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "5becde26ed5357a09c1ebc176835f8d7e2d0a711",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 318,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "05ec13f4192a5a8365083b0f542960a964991cb3",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 325,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "788c11806d77252c63d2c73f51fddeb89226ba5d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 332,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "08cad850b33f483ed00961ba1c8592144c255c14",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 339,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "c1220124a326c63670908390e8815938dab60ff2",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 346,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "9a67a6d67da81b75a26ae3dc801f472c13ad58dc",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 353,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "d5393678a4ec1c040d952bbe4a327900cdcec1e2",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 360,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "096ea0f7699becd97c15b4d14a2fb0e72327efde",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 367,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "e3d8b882b7a53854a870919b043388d92fb691f8",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 374,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "85a69071056763081d613b5324ff7dd7a90021aa",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 381,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "54f952ab262f96d46a8b1d553e6fd386febab14d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 388,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "f2fa0e9a528cebc5d7b89b60e09c87aca05ceed0",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 395,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "122465e4586ee413d18f5d47209439ba576c03dd",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 402,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "9b7a87b7d9081d924c2168de6f878a07f3b788ef",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 409,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "88bbff01bc7c29d6be0aaac2bd0ac0dd087b9a99",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 416,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "f700610b9afd0d66278ade9fcad4697e3f6b37f3",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 423,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "49b08d8fb8e48d71c848034ecde68cb0b2a8c1af",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 430,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "415f9b5ec20f7d2e0e17bd4207d89ee4fe127db9",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 437,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "9f3fd52fe650df90a8d5d372b2283f1644c7256b",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 444,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "3c99adddb8003079faa85fc7889e0f7b2b097e3e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 451,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "ad907166cef9494fd05de523ed872fbe710edfda",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 458,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "6e85815eaca9be15c6729ae0d304863930fd8e39",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 465,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "b7d47fff59afed28687749977742b9b85f69acd7",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 472,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "bd616046d406d83fd7f9713d32dc1764966ed096",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 479,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "4bbd7b8d83bfe27c33df67f9cce63d435b26263a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 486,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "978cd35235412bb6e32999aa90e67288d025dd18",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 493,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "683f06b280ec2f6597ce4a05a3c6220303c45914",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 500,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "faee57361e3af0e263076aa066f3961627514197",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 507,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "6eb9a3b50be02703e7bedfa15d123a8780eee275",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 514,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "db1d5afcb0798f855f65fd291cca1c21372add02",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 521,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "0320ec89366167b036ae50c55523ccc2bc38eed0",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 528,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "518baf890b06b1531eb99ff92e3a9bf6576a3f7d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 535,
+        "type": "Hex High Entropy String"
+      }
+    ]
+  },
+  "version": "0.13.1",
+  "word_list": {
+    "file": null,
+    "hash": null
+  }
+}

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Project Organization
     │
     ├── .gitignore              <- Files and directories to be ignored by git
     │
-    ├── test_environment.py     <- Python environment tester   
+    ├── test_environment.py     <- Python environment tester
     │
     ├── data
     │   ├── external             <- Data from third party sources.
@@ -59,9 +59,9 @@ Project Organization
         ├── make_visualisations  <- Scripts to create exploratory and results oriented visualizations
         │
         └── tools                <- Any helper scripts go here
-           
-     
-   
+       
+
+
 
 --------
 
@@ -71,58 +71,39 @@ Project Organization
 
 ##  Installing pre-commit hooks
 
-  
-
 This repo uses the Python package `pre-commit` (https://pre-commit.com) to manage pre-commit hooks. Pre-commit hooks are
-
 actions which are run automatically, typically on each commit, to perform some common set of tasks. For example, a pre-commit
-
 hook might be used to run any code linting automatically, providing any warnings before code is committed, ensuring that
-
 all of our code adheres to a certain quality standard.
 
-  
-
 For this repo, we are using `pre-commit` for a number of purposes:
-
-- Checking for AWS or private access keys being committed accidentally
-
+- Checking for any secrets being committed accidentally
 - Checking for any large files (over 5MB) being committed
-
 - Cleaning Jupyter notebooks, which means removing all outputs and execution counts
-
 - Running linting on the `src` directory (catching problems before they get to Concourse, which runs the same check)
 
-  
-
 We have configured `pre-commit` to run automatically _when pushing_ rather than on _every commit_, which should mean we
-
 receive the benefits of `pre-commit` without it getting in the way of regular development.
-
-  
 
 In order for `pre-commit` to run, action is needed to configure it on your system.
 
-  
-
 - Run `pip install -r requirements-dev.txt` to install `pre-commit` in your Python environment
+- Run `pre-commit install` to set-up `pre-commit` to run when code is _committed_. By running on each commit, we ensure that
+`pre-commit` will be able to detect all errors and keep our repo in a healthy state.
 
-- Run `pre-commit install -t pre-push` to set-up `pre-commit` to run when code is _pushed_
-
-  
 
 ###  Note on Jupyter notebook cleaning
 
-  
+
 
 It may be necessary or useful to keep certain output cells of a Jupyter notebook, for example charts or graphs visualising
 
 some set of data. To do this, add the following comment at the top of the input block:
 
-  
+
 
 `# [keep_output]`
 
-  
+
 
 This will tell `pre-commit` not to strip the resulting output of this cell, allowing it to be committed.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
+detect-secrets==0.13.1
 pre-commit==2.1.1
 pytest==5.3.5


### PR DESCRIPTION
This PR updates `pre-commit` to use the `detect-secrets` module to detect anything which looks like a secret.

It also updates the instructions for installing `pre-commit` so that it is now run on a per-commit basis (not per-push). This is to ensure better sanitisation of commits (to avoid edge cases where sensitive data could otherwise leak through).