### PR TITLE
Add `vroom` as a dependency

### DIFF
--- a/renv.lock
+++ b/renv.lock
@@ -831,6 +831,13 @@
       "Repository": "CRAN",
       "Hash": "ce4f6271baa94776db692f1cb2055bee"
     },
+    "vroom": {
+      "Package": "vroom",
+      "Version": "1.2.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "5f341c32a91bcf79aca8287822b3d8da"
+    },
     "wakefield": {
       "Package": "wakefield",
       "Version": "0.3.3",


### PR DESCRIPTION
This seems to have been omitted. I get the following error if this isn't
installed:

```
$ R -f src/make_data/fake-data.R
...
> library(PostcodesioR)
> library(generator)
> library(vroom) # to read postcodes file without importing it into
memory
Error in library(vroom) : there is no package called ‘vroom’
Execution halted
```